### PR TITLE
chore: pin GitHub Actions to exact SHAs via pinact

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -18,10 +18,10 @@ jobs:
     name: build and upload artifact
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: './go.mod'
           cache: true
@@ -35,9 +35,9 @@ jobs:
           git diff --staged --quiet || git commit -m "update"
           git push origin HEAD || echo "No changes to push"
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: out
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
This PR pins GitHub Actions to specific commit SHAs using pinact.

Changes:
- actions/checkout -> 08c6903 (v5.0.0)
- actions/setup-go -> d35c59a (v5.5.0)
- actions/configure-pages -> 983d773 (v5.0.0)
- actions/upload-pages-artifact -> 7b1f4a7 (v4.0.0)
- actions/deploy-pages -> d6db901 (v4.0.5)

Generated by running `pinact run` in this repository.
